### PR TITLE
docs: explain differences between test and production examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,19 @@ The Primus zkTLS demo consists of some type examples:
 * The Production Example: https://github.com/primus-labs/zktls-demo/tree/main/production-example
 * The Backend Integration Example: https://github.com/primus-labs/zktls-demo/tree/main/core-sdk-example
 
+## Test Example vs Production Example
+
+Both examples implement the same attestation flow (`generateRequestParams` -> `sign` -> `startAttestation` -> `verifyAttestation`). The difference is **where the attestation request is signed and where the App Secret lives**.
+
+| | Test Example | Production Example |
+|---|---|---|
+| Architecture | Frontend only | Client (web) + Server (Node.js/Express) |
+| Where `sign()` runs | In the browser, via `primusZKTLS.sign()` | On the backend: the client sends the request params to the server's `/primus/sign` endpoint and receives the signed result |
+| App Secret location | Frontend `.env` (`VITE_APP_SECRET`), bundled into client-side code | Server-side `.env` (`APP_SECRET`) only; the client is initialized with the App ID alone |
+| App Secret exposure | **Exposed to anyone who opens the page** - acceptable only for local testing | Never leaves the server |
+| Use when | Quickly trying out the SDK and a template locally | Building anything users will access |
+
+**Never ship the test-example pattern to production.** The App Secret is a credential for your Primus project: if it is embedded in frontend code, anyone can extract it from the bundle and sign attestation requests on behalf of your app. In production, keep the App Secret on a backend you control and expose only a signing endpoint to your client, as shown in the production example.
+
 
 

--- a/production-example/README.md
+++ b/production-example/README.md
@@ -1,4 +1,7 @@
 # zktls-demo production
+
+This example demonstrates the recommended production architecture: the **App Secret stays on the server**, and the client only holds the App ID. The client builds the attestation request, sends it to the server's `/primus/sign` endpoint for signing, and then runs the attestation with the signed request. Compare with the [test example](../test-example), which signs in the browser and is intended for local testing only. See the [Test vs Production comparison](../README.md#test-example-vs-production-example) in the root README.
+
 The Primus zkTLS demo consists of two parts: server and client. You can run it with the following command.
 
 ## Server

--- a/test-example/README.md
+++ b/test-example/README.md
@@ -1,5 +1,7 @@
 # zktls-demo test
 
+> ⚠️ **For local testing only.** This example signs the attestation request directly in the browser, which requires putting the App Secret into frontend environment variables (`VITE_APP_SECRET`). A secret bundled into client-side code can be extracted by anyone. For any user-facing deployment, use the [production example](../production-example), where the App Secret stays on the backend and the client requests signatures from a server endpoint. See the [Test vs Production comparison](../README.md#test-example-vs-production-example) in the root README.
+
 ## Run
 The main code file is this: https://github.com/primus-labs/zktls-demo/blob/main/test-example/src/testprimus.js
 


### PR DESCRIPTION
Closes #2

Adds documentation clarifying the difference between `test-example` and `production-example`, as requested in #2.

## Changes

- **Root `README.md`**: new "Test Example vs Production Example" section with a comparison table. The key distinction documented: both examples run the same attestation flow, but the test example calls `primusZKTLS.sign()` in the browser with the App Secret in frontend env (`VITE_APP_SECRET`), while the production example keeps the App Secret server-side and signs via the `/primus/sign` endpoint.
- **`test-example/README.md`**: warning note that this pattern exposes the App Secret in the client bundle and is for local testing only, with a link to the production example.
- **`production-example/README.md`**: short intro explaining why this is the recommended production architecture, with cross-links.

No code changes.