### PR TITLE
feat: add agent-side verification example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ The Primus zkTLS demo consists of some type examples:
 * The Test Example(just for test): https://github.com/primus-labs/zktls-demo/tree/main/test-example
 * The Production Example: https://github.com/primus-labs/zktls-demo/tree/main/production-example
 * The Backend Integration Example: https://github.com/primus-labs/zktls-demo/tree/main/core-sdk-example
+* The Agent Verification Example: https://github.com/primus-labs/zktls-demo/tree/main/agent-verification-example
 
 
 

--- a/agent-verification-example/.env.example
+++ b/agent-verification-example/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill in your values. Do NOT commit .env.
+APP_ID=YOUR_APPID
+APP_SECRET=YOUR_APPSECRET

--- a/agent-verification-example/.gitignore
+++ b/agent-verification-example/.gitignore
@@ -1,0 +1,29 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Environment variables (contains app credentials, do not commit)
+.env
+.env.local
+.env.*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/agent-verification-example/README.md
+++ b/agent-verification-example/README.md
@@ -1,0 +1,70 @@
+# agent verification example
+
+This example shows what an **autonomous agent** should check *after*
+`zkTLS.verifyAttestation` returns `true`, before it acts on the attested data
+(places an order, signs a transaction, etc.).
+
+`verifyAttestation` confirms the attestor signature and that the attestation is
+internally consistent. It does not, on its own, tell an agent whether the
+attestation is:
+
+- **fresh** enough to act on,
+- **shaped** the way the agent expects (same endpoint and response schema), or
+- **new** (not a replay of a proof already used in a previous run).
+
+The core-sdk example ends with a comment - "Business logic checks, such as
+attestation content and timestamp checks - do your own business logic." This
+example is a concrete, reusable version of that step. A human looking at a
+dashboard would notice a stale or wrong-looking value; an agent acting
+automatically will not, so these checks matter more in the agent case.
+
+## What it does
+
+`agentGuard.js` is a small, dependency-free module with three checks:
+
+| Check | Guards against |
+|---|---|
+| Freshness | Acting on a valid but stale attestation, or one dated in the future |
+| Schema pin | An endpoint that silently changed meaning (units, spot vs mark price, aggregation) while still producing valid proofs |
+| Replay | Re-using a proof from an earlier run to drive a new action |
+
+`index.js` runs the standard attestation flow, then gates the data behind
+`guardAttestation(...)` before treating it as safe to act on.
+
+## Run
+
+Signature verification and attestation generation need Primus credentials:
+
+```bash
+npm install
+# copy .env.example to .env and set APP_ID / APP_SECRET
+node index.js
+```
+
+The guard logic itself has no external dependencies and can be checked offline,
+without credentials or network access:
+
+```bash
+npm test
+```
+
+## Configuration
+
+### App ID and App Secret
+
+Obtain these from the
+[Primus Developer Hub - My Projects](https://dev.primuslabs.xyz/myDevelopment/myProjects).
+Copy `.env.example` to `.env` in this directory and set `APP_ID` and
+`APP_SECRET`. The `.env` file is gitignored - do not commit it.
+
+### Agent policy
+
+Edit `POLICY` in `index.js` to match your agent:
+
+- `maxAgeMs` - maximum accepted attestation age (0 disables the age check).
+- `schema.url` / `schema.method` / `schema.parsePaths` - the endpoint and
+  response paths the agent is built around.
+- `nullifierStore` - in-memory here; back it with a database or an on-chain
+  nullifier map in production so replay protection survives restarts. For the
+  on-chain equivalent, see the `AttestationGuard.sol` pattern in
+  [primus-labs/zktls-contracts](https://github.com/primus-labs/zktls-contracts).

--- a/agent-verification-example/agentGuard.js
+++ b/agent-verification-example/agentGuard.js
@@ -1,0 +1,225 @@
+// agentGuard.js
+//
+// Agent-side checks that run *after* zkTLS.verifyAttestation returns true.
+//
+// zkTLS.verifyAttestation confirms the attestor signature and that the
+// attestation is internally consistent. It does not tell an autonomous agent
+// whether the attestation is:
+//   - fresh enough to act on,
+//   - shaped the way the agent expects (endpoint / response schema),
+//   - being replayed from a previous run.
+//
+// The stock examples end with a comment: "Business logic checks, such as
+// attestation content and timestamp checks - do your own business logic."
+// This module is a concrete, reusable version of that comment, aimed at
+// agents that will act on the data automatically (place an order, sign a tx)
+// rather than show it to a human who might notice something is off.
+//
+// It is transport-agnostic and has no dependencies: pass in the attestation
+// object returned by startAttestation.
+
+/**
+ * Error thrown when an attestation passes signature verification but fails an
+ * agent-side usability check. `reason` is a stable machine-readable code.
+ */
+export class AttestationGuardError extends Error {
+  constructor(reason, message, details = {}) {
+    super(message);
+    this.name = "AttestationGuardError";
+    this.reason = reason; // e.g. "STALE", "FUTURE", "SCHEMA_MISMATCH", "REPLAY"
+    this.details = details;
+  }
+}
+
+/**
+ * Parse the attestation timestamp into epoch milliseconds.
+ *
+ * Primus attestations carry `timestamp` in the same units the on-chain struct
+ * uses. In practice SDK builds have emitted this as milliseconds; some emit
+ * seconds. We normalize defensively: a 10-digit value is treated as seconds,
+ * a 13-digit value as milliseconds.
+ *
+ * @param {object} attestation
+ * @returns {number} epoch milliseconds
+ */
+export function attestationTimestampMs(attestation) {
+  const raw = Number(attestation?.timestamp);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    throw new AttestationGuardError(
+      "NO_TIMESTAMP",
+      "Attestation has no usable timestamp",
+      { timestamp: attestation?.timestamp }
+    );
+  }
+  // < 1e12 => seconds (10-digit epoch), otherwise milliseconds.
+  return raw < 1e12 ? raw * 1000 : raw;
+}
+
+/**
+ * Reject attestations that are too old or dated in the future.
+ *
+ * @param {object} attestation
+ * @param {object} opts
+ * @param {number} opts.maxAgeMs   Maximum accepted age in ms. 0 disables the age check.
+ * @param {number} [opts.clockSkewMs=5000] Tolerance for future-dated timestamps.
+ * @param {number} [opts.now=Date.now()]   Injectable clock for testing.
+ */
+export function checkFreshness(attestation, { maxAgeMs, clockSkewMs = 5000, now = Date.now() }) {
+  const tsMs = attestationTimestampMs(attestation);
+  const age = now - tsMs;
+
+  if (age < -clockSkewMs) {
+    throw new AttestationGuardError(
+      "FUTURE",
+      `Attestation is dated ${-age}ms in the future (beyond ${clockSkewMs}ms skew)`,
+      { attestationTimeMs: tsMs, nowMs: now }
+    );
+  }
+  if (maxAgeMs > 0 && age > maxAgeMs) {
+    throw new AttestationGuardError(
+      "STALE",
+      `Attestation age ${age}ms exceeds maxAgeMs ${maxAgeMs}ms`,
+      { attestationTimeMs: tsMs, nowMs: now, ageMs: age, maxAgeMs }
+    );
+  }
+  return true;
+}
+
+/**
+ * Confirm the attestation was produced for the endpoint and response shape the
+ * agent expects. A template can keep producing valid proofs after an upstream
+ * endpoint silently changes meaning (units, spot vs mark price, aggregation
+ * method); pinning the URL and the response parse paths catches the obvious
+ * cases of that drift before the data is used.
+ *
+ * @param {object} attestation
+ * @param {object} expected
+ * @param {string} [expected.url]            Exact request URL the agent expects.
+ * @param {string} [expected.method]         Expected HTTP method.
+ * @param {string[]} [expected.parsePaths]   Response parse paths that must all be present.
+ */
+export function checkSchema(attestation, expected = {}) {
+  const request = attestation?.request ?? {};
+
+  if (expected.url !== undefined && request.url !== expected.url) {
+    throw new AttestationGuardError(
+      "SCHEMA_MISMATCH",
+      "Attestation request URL does not match expected endpoint",
+      { expected: expected.url, actual: request.url }
+    );
+  }
+
+  if (expected.method !== undefined) {
+    const actualMethod = String(request.method ?? "").toUpperCase();
+    if (actualMethod !== String(expected.method).toUpperCase()) {
+      throw new AttestationGuardError(
+        "SCHEMA_MISMATCH",
+        "Attestation request method does not match expected method",
+        { expected: expected.method, actual: request.method }
+      );
+    }
+  }
+
+  if (Array.isArray(expected.parsePaths) && expected.parsePaths.length > 0) {
+    const resolves = attestation?.reponseResolve ?? attestation?.responseResolve ?? [];
+    const actualPaths = new Set(resolves.map((r) => r.parsePath));
+    const missing = expected.parsePaths.filter((p) => !actualPaths.has(p));
+    if (missing.length > 0) {
+      throw new AttestationGuardError(
+        "SCHEMA_MISMATCH",
+        "Attestation is missing expected response parse paths",
+        { missing, actual: [...actualPaths] }
+      );
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Derive a stable key for an attestation, used for single-use / replay
+ * tracking. Built from the fields the attestor signs over so that a
+ * bit-for-bit resubmission maps to the same key while genuinely distinct
+ * attestations differ.
+ *
+ * Uses Web Crypto (available in Node 18+ and browsers). Returns a hex string.
+ *
+ * @param {object} attestation
+ * @returns {Promise<string>}
+ */
+export async function attestationNullifier(attestation) {
+  const request = attestation?.request ?? {};
+  const resolves = attestation?.reponseResolve ?? attestation?.responseResolve ?? [];
+  const material = JSON.stringify({
+    recipient: attestation?.recipient ?? "",
+    url: request.url ?? "",
+    header: request.header ?? "",
+    method: request.method ?? "",
+    body: request.body ?? "",
+    data: attestation?.data ?? "",
+    attConditions: attestation?.attConditions ?? "",
+    timestamp: attestation?.timestamp ?? "",
+    additionParams: attestation?.additionParams ?? "",
+    resolves: resolves.map((r) => [r.keyName, r.parseType, r.parsePath]),
+    signatures: attestation?.signatures ?? attestation?.signature ?? "",
+  });
+
+  const bytes = new TextEncoder().encode(material);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * In-memory single-use store. For production, back this with a database or an
+ * on-chain nullifier mapping (see the AttestationGuard.sol pattern in
+ * primus-labs/zktls-contracts) so replay protection survives restarts.
+ */
+export class NullifierStore {
+  constructor() {
+    this._seen = new Set();
+  }
+  has(nullifier) {
+    return this._seen.has(nullifier);
+  }
+  add(nullifier) {
+    this._seen.add(nullifier);
+  }
+}
+
+/**
+ * Run all agent-side checks. Assumes zkTLS.verifyAttestation(attestation) has
+ * already returned true - signature verification is not repeated here.
+ *
+ * @param {object} attestation
+ * @param {object} policy
+ * @param {number} policy.maxAgeMs
+ * @param {number} [policy.clockSkewMs]
+ * @param {object} [policy.schema]       Passed to checkSchema.
+ * @param {NullifierStore} [policy.nullifierStore] Enables replay protection when provided.
+ * @param {number} [policy.now]          Injectable clock for testing.
+ * @returns {Promise<{ ok: true, nullifier: string|null }>}
+ */
+export async function guardAttestation(attestation, policy) {
+  checkFreshness(attestation, {
+    maxAgeMs: policy.maxAgeMs,
+    clockSkewMs: policy.clockSkewMs,
+    now: policy.now,
+  });
+
+  if (policy.schema) {
+    checkSchema(attestation, policy.schema);
+  }
+
+  let nullifier = null;
+  if (policy.nullifierStore) {
+    nullifier = await attestationNullifier(attestation);
+    if (policy.nullifierStore.has(nullifier)) {
+      throw new AttestationGuardError("REPLAY", "Attestation has already been consumed", {
+        nullifier,
+      });
+    }
+    policy.nullifierStore.add(nullifier);
+  }
+
+  return { ok: true, nullifier };
+}

--- a/agent-verification-example/agentGuard.test.js
+++ b/agent-verification-example/agentGuard.test.js
@@ -1,0 +1,167 @@
+// agentGuard.test.js
+//
+// Offline tests for the agent-side guard. These use synthetic attestation
+// objects so they run without Primus credentials or network access:
+//
+//   node agentGuard.test.js
+//
+// They document what the guard accepts and rejects. Signature verification is
+// out of scope here - it is done by zkTLS.verifyAttestation before the guard.
+
+import assert from "node:assert";
+import {
+  guardAttestation,
+  checkFreshness,
+  checkSchema,
+  attestationNullifier,
+  NullifierStore,
+  AttestationGuardError,
+} from "./agentGuard.js";
+
+const ENDPOINT = "https://www.okx.com/api/v5/public/instruments?instType=SPOT&instId=BTC-USD";
+const PARSE_PATH = "$.data[0].instType";
+
+// Fixed reference clock (ms).
+const NOW = 1_800_000_000_000;
+
+function sampleAttestation(overrides = {}) {
+  return {
+    recipient: "0x000000000000000000000000000000000000b0b",
+    request: { url: ENDPOINT, header: "", method: "GET", body: "" },
+    reponseResolve: [{ keyName: "instType", parseType: "json", parsePath: PARSE_PATH }],
+    data: '{"instType":"SPOT"}',
+    attConditions: "",
+    timestamp: NOW, // ms
+    additionParams: "",
+    signatures: ["0xdeadbeef"],
+    ...overrides,
+  };
+}
+
+function basePolicy(extra = {}) {
+  return {
+    maxAgeMs: 30_000,
+    clockSkewMs: 5_000,
+    schema: { url: ENDPOINT, method: "GET", parsePaths: [PARSE_PATH] },
+    now: NOW,
+    ...extra,
+  };
+}
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ok  ${name}`);
+    passed += 1;
+  } catch (e) {
+    console.error(`FAIL  ${name}`);
+    console.error("      ", e.message);
+    process.exitCode = 1;
+  }
+}
+
+async function expectReject(reason, fn) {
+  try {
+    await fn();
+    throw new Error(`expected rejection with reason ${reason}, but it passed`);
+  } catch (e) {
+    assert.ok(e instanceof AttestationGuardError, `expected AttestationGuardError, got ${e}`);
+    assert.strictEqual(e.reason, reason, `expected reason ${reason}, got ${e.reason}`);
+  }
+}
+
+const run = async () => {
+  console.log("agentGuard tests");
+
+  // --- freshness ---
+
+  await test("accepts a fresh attestation", async () => {
+    const att = sampleAttestation({ timestamp: NOW - 10_000 });
+    const res = await guardAttestation(att, basePolicy({ nullifierStore: new NullifierStore() }));
+    assert.strictEqual(res.ok, true);
+  });
+
+  await test("rejects a stale attestation", async () => {
+    const att = sampleAttestation({ timestamp: NOW - 60_000 }); // 60s old, max 30s
+    await expectReject("STALE", () => guardAttestation(att, basePolicy()));
+  });
+
+  await test("rejects a future-dated attestation", async () => {
+    const att = sampleAttestation({ timestamp: NOW + 60_000 });
+    await expectReject("FUTURE", () => guardAttestation(att, basePolicy()));
+  });
+
+  await test("tolerates small clock skew", async () => {
+    const att = sampleAttestation({ timestamp: NOW + 3_000 }); // within 5s skew
+    await checkFreshness(att, { maxAgeMs: 30_000, clockSkewMs: 5_000, now: NOW });
+  });
+
+  await test("maxAgeMs=0 disables the age check", async () => {
+    const att = sampleAttestation({ timestamp: NOW - 365 * 24 * 3600 * 1000 });
+    await checkFreshness(att, { maxAgeMs: 0, now: NOW });
+  });
+
+  await test("normalizes second-precision timestamps", async () => {
+    const att = sampleAttestation({ timestamp: Math.floor(NOW / 1000) - 5 }); // seconds
+    await checkFreshness(att, { maxAgeMs: 30_000, now: NOW });
+  });
+
+  // --- schema ---
+
+  await test("rejects a mismatched endpoint", async () => {
+    const att = sampleAttestation({
+      request: { url: "https://evil.example.com/price", method: "GET", body: "", header: "" },
+      timestamp: NOW,
+    });
+    await expectReject("SCHEMA_MISMATCH", () => guardAttestation(att, basePolicy()));
+  });
+
+  await test("rejects a mismatched method", async () => {
+    const att = sampleAttestation({
+      request: { url: ENDPOINT, method: "POST", body: "", header: "" },
+    });
+    await expectReject("SCHEMA_MISMATCH", () =>
+      checkSchema(att, { url: ENDPOINT, method: "GET" })
+    );
+  });
+
+  await test("rejects missing parse paths", async () => {
+    const att = sampleAttestation({
+      reponseResolve: [{ keyName: "x", parseType: "json", parsePath: "$.data[0].other" }],
+    });
+    await expectReject("SCHEMA_MISMATCH", () =>
+      checkSchema(att, { parsePaths: [PARSE_PATH] })
+    );
+  });
+
+  // --- replay ---
+
+  await test("rejects a replayed attestation", async () => {
+    const store = new NullifierStore();
+    const att = sampleAttestation({ timestamp: NOW - 5_000 });
+    const policy = basePolicy({ nullifierStore: store });
+    await guardAttestation(att, policy); // first use ok
+    await expectReject("REPLAY", () => guardAttestation(att, basePolicy({ nullifierStore: store })));
+  });
+
+  await test("distinct attestations get distinct nullifiers", async () => {
+    const a1 = sampleAttestation({ timestamp: NOW - 5_000 });
+    const a2 = sampleAttestation({ timestamp: NOW - 4_000 });
+    const n1 = await attestationNullifier(a1);
+    const n2 = await attestationNullifier(a2);
+    assert.notStrictEqual(n1, n2);
+  });
+
+  await test("nullifier is stable across identical objects", async () => {
+    const a1 = sampleAttestation({ timestamp: NOW - 5_000 });
+    const a2 = sampleAttestation({ timestamp: NOW - 5_000 });
+    const n1 = await attestationNullifier(a1);
+    const n2 = await attestationNullifier(a2);
+    assert.strictEqual(n1, n2);
+  });
+
+  console.log(`\n${passed} passed`);
+};
+
+run();

--- a/agent-verification-example/index.js
+++ b/agent-verification-example/index.js
@@ -1,0 +1,90 @@
+import { PrimusCoreTLS } from "@primuslabs/zktls-core-sdk";
+import "dotenv/config";
+import { guardAttestation, NullifierStore, AttestationGuardError } from "./agentGuard.js";
+
+// The endpoint this agent is built around. Pinning it (and the response parse
+// paths below) is what lets the agent notice if the template later starts
+// producing valid proofs for a different endpoint or response shape.
+const ENDPOINT = "https://www.okx.com/api/v5/public/instruments?instType=SPOT&instId=BTC-USD";
+const PARSE_PATH = "$.data[0].instType";
+
+// Agent policy: how the attestation must look before the agent will act on it.
+const POLICY = {
+  maxAgeMs: 30_000, // reject attestations older than 30s
+  clockSkewMs: 5_000,
+  schema: {
+    url: ENDPOINT,
+    method: "GET",
+    parsePaths: [PARSE_PATH],
+  },
+  // Persist this across runs in production (DB or on-chain nullifier map).
+  nullifierStore: new NullifierStore(),
+};
+
+async function agentProofFlow() {
+  try {
+    const appId = process.env.APP_ID;
+    const appSecret = process.env.APP_SECRET;
+    if (!appId || !appSecret) {
+      throw new Error("Missing APP_ID or APP_SECRET. Copy .env.example to .env and set your credentials.");
+    }
+
+    const zkTLS = new PrimusCoreTLS();
+    const initResult = await zkTLS.init(appId, appSecret);
+    console.log("primusProof initResult=", initResult);
+
+    const request = {
+      url: ENDPOINT,
+      method: "GET",
+      header: {},
+      body: "",
+    };
+    const responseResolves = [
+      { keyName: "instType", parseType: "json", parsePath: PARSE_PATH },
+    ];
+
+    const generateRequest = zkTLS.generateRequestParams(request, responseResolves);
+    generateRequest.setAttMode({ algorithmType: "proxytls" });
+
+    console.log("start attestation!");
+    const attestation = await zkTLS.startAttestation(generateRequest);
+    console.log("attestation=", attestation);
+
+    // Step 1: signature verification (unchanged from the core-sdk example).
+    const verifyResult = zkTLS.verifyAttestation(attestation);
+    console.log("verifyResult=", verifyResult);
+    if (verifyResult !== true) {
+      console.error("Signature verification failed - not acting on this attestation.");
+      process.exit(1);
+    }
+
+    // Step 2: agent-side usability checks. This is the "do your own business
+    // logic" step made concrete: freshness + schema pin + replay protection.
+    try {
+      const { nullifier } = await guardAttestation(attestation, POLICY);
+      console.log("guard passed, nullifier=", nullifier);
+    } catch (e) {
+      if (e instanceof AttestationGuardError) {
+        // A signed, internally-valid attestation that the agent still must not
+        // act on. For an autonomous agent this is the important branch.
+        console.error(`Attestation rejected by guard [${e.reason}]: ${e.message}`);
+        console.error("details=", e.details);
+        process.exit(2);
+      }
+      throw e;
+    }
+
+    // Step 3: only now is it safe for the agent to act on attestation data.
+    console.log("Attestation is verified, fresh, schema-matched and unused - safe to act on.");
+
+    process.exit(0);
+  } catch (error) {
+    console.error("Attestation error:", error);
+    if (error?.code) {
+      console.error(`${error?.code}: ${error?.message}`);
+    }
+    process.exit(1);
+  }
+}
+
+agentProofFlow();

--- a/agent-verification-example/package.json
+++ b/agent-verification-example/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "agent-verification-example",
+  "version": "1.0.0",
+  "description": "Primus zkTLS agent-side verification example: freshness, schema, and replay checks after verifyAttestation",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node agentGuard.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/primus-labs/zktls-demo.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/primus-labs/zktls-demo/issues"
+  },
+  "homepage": "https://github.com/primus-labs/zktls-demo#readme",
+  "dependencies": {
+    "@primuslabs/zktls-core-sdk": "^0.2.6",
+    "dotenv": "^17.2.3",
+    "tslib": "^2.8.1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new example, `agent-verification-example`, showing what an **autonomous agent** should check *after* `zkTLS.verifyAttestation` returns `true`, before it acts on the attested data (places an order, signs a transaction, etc.).

`verifyAttestation` confirms the attestor signature and internal consistency. It does not, on its own, tell an agent whether the attestation is:

- **fresh** enough to act on,
- **shaped** the way the agent expects (same endpoint and response schema), or
- **new** (not a replay of a proof used in an earlier run).

The existing `core-sdk-example` ends with a comment - "Business logic checks, such as attestation content and timestamp checks - do your own business logic." This PR turns that comment into a concrete, reusable step. The distinction matters most for agents: a human looking at a dashboard would notice a stale or wrong-looking value; an agent acting automatically will not.

## Contents

- **`agentGuard.js`** - dependency-free module with three checks: freshness (max age + future-timestamp rejection), schema pin (URL / method / response parse paths), and replay protection (per-attestation nullifier via Web Crypto SHA-256).
- **`index.js`** - the standard attestation flow from `core-sdk-example`, with the attested data gated behind `guardAttestation(...)` before it is treated as safe to act on.
- **`agentGuard.test.js`** - 12 offline tests (`npm test`) using synthetic attestations, so reviewers can verify the logic without Primus credentials or network access.
- README, `package.json`, `.env.example`, `.gitignore` mirroring `core-sdk-example`.

## Testing

```bash
cd agent-verification-example
npm test        # 12 passing, offline, no credentials
```

Running the full flow (`node index.js`) needs `APP_ID` / `APP_SECRET` as with the other examples.

## Notes

The in-memory nullifier store is documented as needing a persistent backend in production; the README links the on-chain equivalent (`AttestationGuard.sol` pattern) for teams doing on-chain verification. No changes to existing examples.
